### PR TITLE
Fix text not occupying entire available parent container width

### DIFF
--- a/src/components/TodoItem/todoItem.module.css
+++ b/src/components/TodoItem/todoItem.module.css
@@ -3,6 +3,7 @@
   display: inline-block;
   text-decoration: none;
   word-wrap: break-word;
+  width: 100%;
 }
 
 .item.completed svg {


### PR DESCRIPTION
* Just needed to make sure the input component was 100% the width of the parent container